### PR TITLE
added manage_api_clients to scopes because manage_project scope is no…

### DIFF
--- a/builder-renderer/generated-code/src/test/java/commercetools/utils/CommercetoolsTestUtils.java
+++ b/builder-renderer/generated-code/src/test/java/commercetools/utils/CommercetoolsTestUtils.java
@@ -42,7 +42,7 @@ public class CommercetoolsTestUtils {
     }
 
     public static String getScopes() {
-        return "manage_project:"+getProjectKey();
+        return "manage_project:"+getProjectKey() + " manage_api_clients:"+getProjectKey();
     }
 
     public static ApiRoot getApiRoot(){


### PR DESCRIPTION
…t enough to manage api clients. Api Clients integration tests were failing because of this.