### PR TITLE
fixed token suppliers silent failing

### DIFF
--- a/commercetools/commercetools-api-default/src/test/java/commercetools/oauth/AnonymousSessionAuthIntegrationTest.java
+++ b/commercetools/commercetools-api-default/src/test/java/commercetools/oauth/AnonymousSessionAuthIntegrationTest.java
@@ -6,6 +6,8 @@ import io.vrap.rmf.impl.okhttp.VrapOkhttpClient;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.concurrent.ExecutionException;
+
 import static commercetools.utils.CommercetoolsTestUtils.*;
 
 public class AnonymousSessionAuthIntegrationTest {
@@ -29,6 +31,19 @@ public class AnonymousSessionAuthIntegrationTest {
         }catch (Exception e){
             Assert.fail("Failed to obtain anonymous session token");
         }
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void throwExceptionWrongCredentials() throws Exception {
+        AnonymousSessionTokenSupplier anonymousSessionTokenSupplier = new AnonymousSessionTokenSupplier(
+                "wrong-client-id",
+                getClientSecret(),
+                "",
+                "https://auth.sphere.io/oauth/" + getProjectKey() + "/anonymous/token",
+                vrapHttpClient
+        );
+
+        anonymousSessionTokenSupplier.getToken().get();
     }
     
 }

--- a/commercetools/commercetools-api-default/src/test/java/commercetools/oauth/ClientCredentialsTokenSupplierIntegrationTests.java
+++ b/commercetools/commercetools-api-default/src/test/java/commercetools/oauth/ClientCredentialsTokenSupplierIntegrationTests.java
@@ -1,0 +1,27 @@
+package commercetools.oauth;
+
+import io.vrap.rmf.base.client.VrapHttpClient;
+import io.vrap.rmf.base.client.oauth2.ClientCredentialsTokenSupplier;
+import io.vrap.rmf.impl.okhttp.VrapOkhttpClient;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+
+public class ClientCredentialsTokenSupplierIntegrationTests {
+
+    private static final VrapHttpClient vrapHttpClient = new VrapOkhttpClient();
+    
+    @Test(expected = ExecutionException.class)
+    public void throwExceptionWrongCredentials() throws Exception {
+        ClientCredentialsTokenSupplier clientCredentialsTokenSupplier  = new ClientCredentialsTokenSupplier(
+                "wrong-client-id",
+                "wrong-client-secret",
+                "",
+                "https://auth.sphere.io/oauth/token"
+                , vrapHttpClient
+        );
+
+        clientCredentialsTokenSupplier.getToken().get();
+    }
+    
+}

--- a/commercetools/commercetools-api-default/src/test/java/commercetools/oauth/GlobalCustomerPasswordAuthIntegrationTest.java
+++ b/commercetools/commercetools-api-default/src/test/java/commercetools/oauth/GlobalCustomerPasswordAuthIntegrationTest.java
@@ -11,6 +11,8 @@ import io.vrap.rmf.impl.okhttp.VrapOkhttpClient;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.concurrent.ExecutionException;
+
 import static commercetools.utils.CommercetoolsTestUtils.*;
 
 public class GlobalCustomerPasswordAuthIntegrationTest {
@@ -55,5 +57,20 @@ public class GlobalCustomerPasswordAuthIntegrationTest {
         }finally {
             CustomerFixtures.deleteCustomer(customer.getId(), customer.getVersion());
         }
+    }
+    
+    @Test(expected = ExecutionException.class)
+    public void throwExceptionWrongCredentials() throws Exception {
+        GlobalCustomerPasswordTokenSupplier globalCustomerPasswordTokenSupplier = new GlobalCustomerPasswordTokenSupplier(
+                getClientId(),
+                getClientSecret(),
+                "wront-email@test.com",
+                "wrong-password",
+                "",
+                "https://auth.sphere.io/oauth/" + getProjectKey() + "/customers/token",
+                vrapHttpClient
+        );
+        
+        globalCustomerPasswordTokenSupplier.getToken().get();
     }
 }

--- a/rmf/rmf-java-base/src/main/java/io/vrap/rmf/base/client/oauth2/ClientCredentialsTokenSupplier.java
+++ b/rmf/rmf-java-base/src/main/java/io/vrap/rmf/base/client/oauth2/ClientCredentialsTokenSupplier.java
@@ -7,6 +7,7 @@ import io.vrap.rmf.base.client.utils.json.VrapJsonUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class ClientCredentialsTokenSupplier implements TokenSupplier {
 
@@ -29,6 +30,12 @@ public class ClientCredentialsTokenSupplier implements TokenSupplier {
     public CompletableFuture<AuthenticationToken> getToken() {
         return vrapHttpClient
                 .execute(apiHttpRequest)
+                .thenApply(apiHttpResponse -> {
+                    if(apiHttpResponse.getStatusCode() < 200 || apiHttpResponse.getStatusCode() > 299) {
+                        throw new CompletionException(new Throwable(new String(apiHttpResponse.getBody())));
+                    }
+                    return apiHttpResponse;
+                })
                 .thenApply(
                         Utils.wrapToCompletionException(
                                 (ApiHttpResponse<byte[]> response) -> VrapJsonUtils.fromJsonByteArray(response.getBody(), AuthenticationToken.class)

--- a/rmf/rmf-java-base/src/main/java/io/vrap/rmf/base/client/oauth2/GlobalCustomerPasswordTokenSupplier.java
+++ b/rmf/rmf-java-base/src/main/java/io/vrap/rmf/base/client/oauth2/GlobalCustomerPasswordTokenSupplier.java
@@ -7,6 +7,7 @@ import io.vrap.rmf.base.client.utils.json.VrapJsonUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 public class GlobalCustomerPasswordTokenSupplier implements TokenSupplier {
 
@@ -22,6 +23,12 @@ public class GlobalCustomerPasswordTokenSupplier implements TokenSupplier {
     public CompletableFuture<AuthenticationToken> getToken() {
         return vrapHttpClient
                 .execute(apiHttpRequest)
+                .thenApply(apiHttpResponse -> {
+                    if(apiHttpResponse.getStatusCode() < 200 || apiHttpResponse.getStatusCode() > 299) {
+                        throw new CompletionException(new Throwable(new String(apiHttpResponse.getBody())));
+                    }
+                    return apiHttpResponse;
+                })
                 .thenApply(
                         Utils.wrapToCompletionException(
                                 (ApiHttpResponse<byte[]> response) -> VrapJsonUtils.fromJsonByteArray(response.getBody(), AuthenticationToken.class)


### PR DESCRIPTION
The problem which this PR is solving is that when obtaining access token fails, token suppliers just return AuthenticationToken instance with all fields as null. This PR adds support for throwing "CompletionException" inside of token suppliers when token endpoints returns status code outside 200-299. This allows users to see the text of the error message.