### PR TITLE
LoggerMiddleware now prints logs in one line to reduce output. Otherwise builds fail on travis.

### DIFF
--- a/rmf/rmf-java-base/src/main/java/io/vrap/rmf/base/client/middlewares/LoggerMiddleware.java
+++ b/rmf/rmf-java-base/src/main/java/io/vrap/rmf/base/client/middlewares/LoggerMiddleware.java
@@ -27,7 +27,7 @@ public final class LoggerMiddleware implements Middleware {
             loggerMessage.setResponseHeaders(arg.getResponse().getHeaders());
             loggerMessage.setResponseBody(new String(arg.getResponse().getBody()));
             
-            String loggerMessageString = VrapJsonUtils.getConfiguredObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(loggerMessage);
+            String loggerMessageString = VrapJsonUtils.getConfiguredObjectMapper().writeValueAsString(loggerMessage);
             LOGGER.info(loggerMessageString);
         }catch (JsonProcessingException error){
             MiddlewareArg args = MiddlewareArg.from(arg.getRequest(), arg.getResponse(), error, arg.getNext());


### PR DESCRIPTION
While runnning integration tests on Travis CI, logger is outputing too much. This causes travis to kill our build.