### PR TITLE
make api methods comparable

### DIFF
--- a/rmf/rmf-java-base/src/main/java/io/vrap/rmf/base/client/ApiMethod.java
+++ b/rmf/rmf-java-base/src/main/java/io/vrap/rmf/base/client/ApiMethod.java
@@ -15,9 +15,9 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
-public abstract class ApiMethod<T extends ApiMethod<T, TResult>, TResult>
+public abstract class ApiMethod<T extends ApiMethod<T, TResult>, TResult> extends Base
         implements RequestCommand<TResult>, ClientRequestCommand<TResult> {
-    public static class ParamEntry<K, V> implements Map.Entry<K, V> {
+    public static class ParamEntry<K, V> extends Base implements Map.Entry<K, V> {
         protected final K key;
         protected V value;
 


### PR DESCRIPTION
In order to make it easier to test resulting requests to expected requests, it would be nice to have the `ApiMethod` extend from `Base` in order to inherit the `equals` and `hashCode` methods.

So, instead of comparing field by field, this enables test code like:

```java

  @Test
  void adaptsFromPageable() {
    // given
    final ApiHttpClient client = mock(ApiHttpClient.class);
    final ByProjectKeyProductProjectionsGet adaptee =
        new ByProjectKeyProductProjectionsRequestBuilder(client, "projectKey")
            .get();
    final PageRequest pageRequest =
        PageRequest.of(10, 50, Sort.by("createdAt").descending().and(Sort.by("id").ascending()));

    // when
    final ByProjectKeyProductProjectionsGet result = toTest.adapt(adaptee, pageRequest);

    // then
    final ByProjectKeyProductProjectionsGet expectedResult =
        new ByProjectKeyProductProjectionsRequestBuilder(client, "projectKey")
            .get()
            .withLimit(50)
            .addSort("createdAt DESC")
            .addSort("id ASC")
            .withOffset(450);

    assertEquals(expectedResult, result);
  }

```

@jenschude 