### PR TITLE
chore(docs): update naming to match new branding initiative

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Introduction
 
-This repository contains the commercetools Composable Commerce and import-api java sdks generated from our api reference.
+This repository contains the commercetools Composable Commerce and Import API Java SDKs generated from our API reference.
 
 * [Getting Started](https://commercetools.github.io/commercetools-sdk-java-v2/javadoc/com/commercetools/docs/meta/GettingStarted.html)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="build/theme/resources/CT_cube_200px.png" width="40" align="center"></img> commercetools JAVA SDK
+# <img src="build/theme/resources/CT_cube_200px.png" width="40" align="center"></img> commercetools Composable Commerce JAVA SDK
 
 
 [![][maven img]][maven]
@@ -7,7 +7,7 @@
 
 ## Introduction
 
-This repository contains the commercetools platform and import-api java sdks generated from our api reference.
+This repository contains the commercetools Composable Commerce and import-api java sdks generated from our api reference.
 
 * [Getting Started](https://commercetools.github.io/commercetools-sdk-java-v2/javadoc/com/commercetools/docs/meta/GettingStarted.html)
 

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ class Version {
 
 allprojects {
     apply from: "$rootDir/gradle-scripts/repositories.gradle"
-    description = "The e-commerce SDK from commercetools for Java"
+    description = "The e-commerce SDK from commercetools Composable Commerce for Java"
 }
 
 apply from: "$rootDir/gradle-scripts/repositories.gradle"

--- a/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/ExceptionDocumentation.java
+++ b/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/ExceptionDocumentation.java
@@ -12,7 +12,7 @@ package com.commercetools.docs.meta;
  *
  * <p>JSON serializing and deserializing problems throw {@link io.vrap.rmf.base.client.utils.json.JsonException}.</p>
  *
- * <p>{@link io.vrap.rmf.base.client.ApiHttpException} is a base exception for all error responses from the commercetools platform (HTTP status code {@code >= 400}).</p>
+ * <p>{@link io.vrap.rmf.base.client.ApiHttpException} is a base exception for all error responses from the commercetools Composable Commerce (HTTP status code {@code >= 400}).</p>
  *
  * <p>{@link io.vrap.rmf.base.client.error.ApiClientException} expresses errors which can be recovered by the client side (HTTP status code {@code >= 400 and < 500}).
  * {@link io.vrap.rmf.base.client.error.ApiServerException} is for server errors.</p>

--- a/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/ExceptionDocumentation.java
+++ b/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/ExceptionDocumentation.java
@@ -22,7 +22,7 @@ package com.commercetools.docs.meta;
  * <h3>Errors</h3>
  *
  * If a command cannot be performed due to unfulfilled preconditions
- * the platform can return one error response with multiple errors (<a href="https://docs.commercetools.com/api/errors">listing of error codes</a>).
+ * the API can return one error response with multiple errors (<a href="https://docs.commercetools.com/api/errors">listing of error codes</a>).
  * The SDK will then put a {@link io.vrap.rmf.base.client.error.BadRequestException} into a {@link java.util.concurrent.CompletionStage}.
  *
  * <h3>Custom HttpExceptionFactory</h3>

--- a/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/ExceptionDocumentation.java
+++ b/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/ExceptionDocumentation.java
@@ -12,7 +12,7 @@ package com.commercetools.docs.meta;
  *
  * <p>JSON serializing and deserializing problems throw {@link io.vrap.rmf.base.client.utils.json.JsonException}.</p>
  *
- * <p>{@link io.vrap.rmf.base.client.ApiHttpException} is a base exception for all error responses from the commercetools Composable Commerce (HTTP status code {@code >= 400}).</p>
+ * <p>{@link io.vrap.rmf.base.client.ApiHttpException} is a base exception for all error responses from Composable Commerce (HTTP status code {@code >= 400}).</p>
  *
  * <p>{@link io.vrap.rmf.base.client.error.ApiClientException} expresses errors which can be recovered by the client side (HTTP status code {@code >= 400 and < 500}).
  * {@link io.vrap.rmf.base.client.error.ApiServerException} is for server errors.</p>

--- a/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/GeneralConcept.java
+++ b/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/GeneralConcept.java
@@ -8,7 +8,7 @@ import io.vrap.rmf.base.client.ApiMethod;
 /**
  * <h2 id=general-concept>General concept of the SDK</h2>
  *
- * The SDK provides classes and interfaces to interact with the commercetools Composable Commerce APIs in an object oriented way.
+ * The SDK provides classes and interfaces to interact with the commercetools Composable Commerce APIs in an object-oriented way.
  *
  * <h3>ApiHttpClient</h3>
  *

--- a/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/GeneralConcept.java
+++ b/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/GeneralConcept.java
@@ -8,7 +8,7 @@ import io.vrap.rmf.base.client.ApiMethod;
 /**
  * <h2 id=general-concept>General concept of the SDK</h2>
  *
- * The SDK provides classes and interfaces to interact with the commercetools APIs in an object oriented way.
+ * The SDK provides classes and interfaces to interact with the commercetools Composable Commerce APIs in an object oriented way.
  *
  * <h3>ApiHttpClient</h3>
  *

--- a/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/GettingStarted.java
+++ b/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/GettingStarted.java
@@ -4,7 +4,7 @@ package com.commercetools.docs.meta;
 /**
  * <h2 id=about-clients>About the client</h2>
  *
- * <p>The commercetools platform client communicates asynchronously with the API via HTTPS
+ * <p>The commercetools Composable Commerce client communicates asynchronously with the API via HTTPS
  * and it takes care about authentication.</p>
  *
  * <p>The client uses Java objects to formulate an HTTP request, performs the request and

--- a/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/Logging.java
+++ b/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/Logging.java
@@ -38,7 +38,7 @@ package com.commercetools.docs.meta;
  *
  * <p>The child loggers of commercetools Composable Commerce correspond with the names of the API endpoints, so for example {@code commercetools.categories} for Categories and {@code commercetools.product-types} for Product Types.</p>
  *
- * <p>The grandchild loggers refer to the action. {@code commercetools.categories.request} refers to performing requests per HTTPS to commercetools Composable Commerce for categories, {@code commercetools.categories.response} refers to the responses of the platform.</p>
+ * <p>The grandchild loggers refer to actions. For example, {@code commercetools.categories.request} refers to performing requests via HTTPs to commercetools Composable Commerce for Categories and {@code commercetools.categories.response} refers to the response for Categories. </p>
  *
  * <p>The logger makes use of different log levels, so for example {@code commercetools.categories.response} logs on debug level the http response from the platform (abbreviated example):</p>
  *

--- a/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/Logging.java
+++ b/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/Logging.java
@@ -4,7 +4,7 @@ package com.commercetools.docs.meta;
 /**
  * <h2 id=logging>Logging</h2>
  *
- * <p>Internal logging used by the commercetools client itself. Uses slf4j logger named {@code commercetools}.</p>
+ * <p>Internal logging used by the commercetools Composable Commerce client itself. Uses slf4j logger named {@code commercetools}.</p>
  *
  * <h2 id=log-information>Log Information</h2>
  *
@@ -36,9 +36,9 @@ package com.commercetools.docs.meta;
  *
  * <p>The loggers form a hierarchy separated by a dot. The root logger is {@code commercetools}.</p>
  *
- * <p>The child loggers of commercetools are the endpoints, so for example {@code commercetools.categories} for categories and {@code commercetools.product-types} for product types.</p>
+ * <p>The child loggers of commercetools Composable Commerce are the endpoints, so for example {@code commercetools.categories} for categories and {@code commercetools.product-types} for product types.</p>
  *
- * <p>The grandchild loggers refer to the action. {@code commercetools.categories.request} refers to performing requests per HTTPS to commercetools for categories, {@code commercetools.categories.response} refers to the responses of the platform.</p>
+ * <p>The grandchild loggers refer to the action. {@code commercetools.categories.request} refers to performing requests per HTTPS to commercetools Composable Commerce for categories, {@code commercetools.categories.response} refers to the responses of the platform.</p>
  *
  * <p>The logger makes use of different log levels, so for example {@code commercetools.categories.response} logs on debug level the http response from the platform (abbreviated example):</p>
  *

--- a/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/Logging.java
+++ b/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/Logging.java
@@ -36,7 +36,7 @@ package com.commercetools.docs.meta;
  *
  * <p>The loggers form a hierarchy separated by a dot. The root logger is {@code commercetools}.</p>
  *
- * <p>The child loggers of commercetools Composable Commerce are the endpoints, so for example {@code commercetools.categories} for categories and {@code commercetools.product-types} for product types.</p>
+ * <p>The child loggers of commercetools Composable Commerce correspond with the names of the API endpoints, so for example {@code commercetools.categories} for Categories and {@code commercetools.product-types} for Product Types.</p>
  *
  * <p>The grandchild loggers refer to the action. {@code commercetools.categories.request} refers to performing requests per HTTPS to commercetools Composable Commerce for categories, {@code commercetools.categories.response} refers to the responses of the platform.</p>
  *

--- a/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/Logging.java
+++ b/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/Logging.java
@@ -46,7 +46,7 @@ package com.commercetools.docs.meta;
  * [OkHttp https://api.europe-west1.gcp.commercetools.com/...] DEBUG commercetools.categories.response - io.vrap.rmf.base.client.ApiHttpResponse@33e37acd[statusCode=200,headers=...,textInterpretedBody={"limit":20,"offset":0,"count":4,"total":4,"results":[{"id":"ca7f64dc-ab41-4e7f-b65b-bfc25bf01111","version":1,"createdAt":"2021-01-06T09:21:55.445Z","lastModifiedAt":"2021-01-06T09:21:55.445Z","key":"random-key-15aab6ee-9a48-4fdc-a8c3-8ff9ff390d60","name":{"key-6bc3cc62-1995-43f4":"value-random-string-c3ff7f1a-6371-4c0c-a3b9-5060eca08b8a"},"slug":{"key-6bc3cc62-1995-43f4":"value-random-string-c3ff7f1a-6371-4c0c-a3b9-5060eca08b8a"},"description":{"key-6bc3cc62-1995-43f4":"value-random-string-c3ff7f1a-6371-4c0c-a3b9-5060eca08b8a"},"ancestors":[],"orderHint":"random-string-a99e6941-3225-4766-923a-4a654652532f","externalId":"random-id-100b3851-29b4-47c1-aef3-860b4cd28f54"}]}]
  * }</pre>
  *
- * <p>{@code commercetools.categories.response} logs on trace level additional the formatted http response from the platform (abbreviated example):</p>
+ * <p>{@code commercetools.categories.response} logs on trace level additional the formatted http response from the API (abbreviated example):</p>
  *
  * <pre>{@code
  * [OkHttp https://api.europe-west1.gcp.commercetools.com/...] TRACE commercetools.categories.response - 200

--- a/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/Middlewares.java
+++ b/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/Middlewares.java
@@ -17,7 +17,7 @@ package com.commercetools.docs.meta;
 
     <h3>OAuthMiddleware</h3>
 
-    <p>An {@link io.vrap.rmf.base.client.http.OAuthMiddleware} is used to authenticate a request against the commercetools
+    <p>An {@link io.vrap.rmf.base.client.http.OAuthMiddleware} is used to authenticate a request against the commercetools Composable Commerce
     APIs. The default implementation adds an auth header to the request instance. In case of an expired token it will try to
     reauthenticate automatically. To retrieve an {@link io.vrap.rmf.base.client.AuthenticationToken} the
     {@link io.vrap.rmf.base.client.http.OAuthHandler} is called.</p>

--- a/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/Querying.java
+++ b/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/Querying.java
@@ -6,7 +6,7 @@ package com.commercetools.docs.meta;
  *
  * <h3>Predicates</h3>
  *
- * <p>The platform allows the use of <a href="https://docs.commercetools.com/api/predicates/query">predicates</a> when
+ * <p>The system allows the use of <a href="https://docs.commercetools.com/api/predicates/query">predicates</a> when
  * querying the API. Predicates are added as query parameter string to the request itself. The following example shows
  * the usage of <a href="https://docs.commercetools.com/api/predicates/query#input-variable-examples">input variables</a></p>
  *

--- a/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/Using.java
+++ b/commercetools/internal-docs/src/main/java/com/commercetools/docs/meta/Using.java
@@ -22,7 +22,7 @@ import io.vrap.rmf.base.client.ApiMethod;
  * <h3>Request DSL</h3>
  *
  * <p>Building request can be done with the help of an ApiRoot, e.g. {@link com.commercetools.api.client.ProjectApiRoot}.
- * The DSL mirrors the directory structure and HTTP methods of the API and allows navigating and discovering the commercetools
+ * The DSL mirrors the directory structure and HTTP methods of the API and allows navigating and discovering the commercetools Composable Commerce
  * API while typing. The HTTP method builders includes methods for every query parameter. Additionally there are
  * the {@link ApiMethod#execute()} and {@link ApiMethod#executeBlocking()} methods which are sending the request using the
  * configured {@link io.vrap.rmf.base.client.ApiHttpClient} and mapping the result to the correct response class. In case

--- a/examples/spring/src/main/resources/templates/home/index.html
+++ b/examples/spring/src/main/resources/templates/home/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" th:replace="~{shared/layout :: layout(~{::title}, ~{::section})}">
 <head>
-    <title>commercetools Spring example</title>
+    <title>commercetools Composable Commerce Spring example</title>
 </head>
 <body>
 <section>
-    <p>This is an example application showing the integration of commercetools in a Spring Boot webflux environment.</p>
+    <p>This is an example application showing the integration of commercetools Composable Commerce in a Spring Boot webflux environment.</p>
 </section>
 </body>
 </html>

--- a/rmf/rmf-java-base/src/main/java/io/vrap/rmf/base/client/utils/json/JsonUtils.java
+++ b/rmf/rmf-java-base/src/main/java/io/vrap/rmf/base/client/utils/json/JsonUtils.java
@@ -119,7 +119,7 @@ public class JsonUtils {
     }
 
     /**
-     * Converts a commercetools platform Java object to JSON as {@link JsonNode}.
+     * Converts a commercetools Composable Commerce Java object to JSON as {@link JsonNode}.
      * <p>If {@code value} is of type String and contains JSON data, that will be ignored, {@code value} will be treated as just any String.
      * If you want to parse a JSON String to a JsonNode use {@link JsonUtils#parse(java.lang.String)} instead.</p>
      * <p>

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -1,5 +1,5 @@
 <body>
-    commercetools platform Java SDK.
+    commercetools Composable Commerce Java SDK.
     <div class="pull-up">
         <h1 class="toc-ignore">Pages about the SDK</h1>
 


### PR DESCRIPTION
This PR follows the rebranding initiative by the Marketing and Docs team to change `commercetools` to `Composable Commerce`.

https://github.com/commercetools/clients-team-internal/issues/87