### PR TITLE
refactor properties with union types

### DIFF
--- a/api-java-mixin.raml
+++ b/api-java-mixin.raml
@@ -72,6 +72,16 @@ types:
     (java-extends): 'com.commercetools.api.models.CustomizableDraft<AssetDraft>, com.commercetools.api.models.WithKey'
   LocalizedString:
     (java-extends): 'com.commercetools.api.models.common.LocalizedStringUtil'
+  ReplicaCartDraft:
+    (java-mixin): |
+      @JsonIgnore
+      @Deprecated
+      public default void setReference(final Object reference) {
+          setReference((Reference)reference);
+      };
+    properties:
+      reference:
+        type: Reference
   Cart:
     (java-extends): 'com.commercetools.api.models.DomainResource<Cart>, com.commercetools.api.models.Referencable<Cart>, com.commercetools.api.models.ResourceIdentifiable<Cart>, com.commercetools.api.models.Customizable<Cart>, com.commercetools.api.models.order.OrderLike<Cart>, com.commercetools.api.models.WithKey'
     (java-mixin): |
@@ -537,8 +547,25 @@ types:
       public static com.commercetools.api.models.common.ReferenceTypeId referenceTypeId() {
           return com.commercetools.api.models.common.ReferenceTypeId.REVIEW;
       }
+      @Deprecated
+      @JsonIgnore
+      public default void setTarget(final Object target) {
+          setTarget((Reference)target);
+      };
+    properties:
+      target?:
+        type: Reference
   ReviewDraft:
     (java-extends): 'com.commercetools.api.models.CustomizableDraft<ReviewDraft>, com.commercetools.api.models.WithKey'
+    (java-mixin): |
+      @Deprecated
+      @JsonIgnore
+      public default void setTarget(final Object target) {
+          setTarget((ResourceIdentifier)target);
+      };
+    properties:
+      target?:
+        type: ResourceIdentifier
   ReviewPagedQueryResponse:
     (java-extends): 'com.commercetools.api.models.ResourcePagedQueryResponse<Review>'
   ReviewReference:

--- a/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/cart/ReplicaCartDraft.java
+++ b/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/cart/ReplicaCartDraft.java
@@ -5,9 +5,10 @@ import java.time.*;
 import java.util.*;
 import java.util.function.Function;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
-import com.commercetools.api.models.order.OrderReference;
+import com.commercetools.api.models.common.Reference;
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.*;
 
@@ -21,6 +22,7 @@ import io.vrap.rmf.base.client.utils.Generated;
  * <div class=code-example>
  * <pre><code class='java'>
  *     ReplicaCartDraft replicaCartDraft = ReplicaCartDraft.builder()
+ *             .reference(referenceBuilder -> referenceBuilder)
  *             .build()
  * </code></pre>
  * </div>
@@ -30,11 +32,12 @@ import io.vrap.rmf.base.client.utils.Generated;
 public interface ReplicaCartDraft extends io.vrap.rmf.base.client.Draft<ReplicaCartDraft> {
 
     /**
-     *
+     *  <p>A Reference represents a loose reference to another resource in the same Project identified by its <code>id</code>. The <code>typeId</code> indicates the type of the referenced resource. Each resource type has its corresponding Reference type, like ChannelReference. A referenced resource can be embedded through Reference Expansion. The expanded reference is the value of an additional <code>obj</code> field then.</p>
      */
     @NotNull
+    @Valid
     @JsonProperty("reference")
-    public Object getReference();
+    public Reference getReference();
 
     /**
      *  <p>User-specific unique identifier of the cart.</p>
@@ -43,11 +46,7 @@ public interface ReplicaCartDraft extends io.vrap.rmf.base.client.Draft<ReplicaC
     @JsonProperty("key")
     public String getKey();
 
-    public void setReference(final CartReference reference);
-
-    public void setReference(final OrderReference reference);
-
-    public void setReference(final Object reference);
+    public void setReference(final Reference reference);
 
     public void setKey(final String key);
 
@@ -73,6 +72,12 @@ public interface ReplicaCartDraft extends io.vrap.rmf.base.client.Draft<ReplicaC
     default <T> T withReplicaCartDraft(Function<ReplicaCartDraft, T> helper) {
         return helper.apply(this);
     }
+
+    @JsonIgnore
+    @Deprecated
+    public default void setReference(final Object reference) {
+        setReference((Reference) reference);
+    };
 
     public static com.fasterxml.jackson.core.type.TypeReference<ReplicaCartDraft> typeReference() {
         return new com.fasterxml.jackson.core.type.TypeReference<ReplicaCartDraft>() {

--- a/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/cart/ReplicaCartDraftBuilder.java
+++ b/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/cart/ReplicaCartDraftBuilder.java
@@ -2,6 +2,7 @@
 package com.commercetools.api.models.cart;
 
 import java.util.*;
+import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
@@ -15,6 +16,7 @@ import io.vrap.rmf.base.client.utils.Generated;
  * <div class=code-example>
  * <pre><code class='java'>
  *     ReplicaCartDraft replicaCartDraft = ReplicaCartDraft.builder()
+ *             .reference(referenceBuilder -> referenceBuilder)
  *             .build()
  * </code></pre>
  * </div>
@@ -22,17 +24,27 @@ import io.vrap.rmf.base.client.utils.Generated;
 @Generated(value = "io.vrap.rmf.codegen.rendering.CoreCodeGenerator", comments = "https://github.com/commercetools/rmf-codegen")
 public class ReplicaCartDraftBuilder implements Builder<ReplicaCartDraft> {
 
-    private java.lang.Object reference;
+    private com.commercetools.api.models.common.Reference reference;
 
     @Nullable
     private String key;
 
     /**
-     *
+     *  <p>A Reference represents a loose reference to another resource in the same Project identified by its <code>id</code>. The <code>typeId</code> indicates the type of the referenced resource. Each resource type has its corresponding Reference type, like ChannelReference. A referenced resource can be embedded through Reference Expansion. The expanded reference is the value of an additional <code>obj</code> field then.</p>
      */
 
-    public ReplicaCartDraftBuilder reference(final java.lang.Object reference) {
+    public ReplicaCartDraftBuilder reference(final com.commercetools.api.models.common.Reference reference) {
         this.reference = reference;
+        return this;
+    }
+
+    /**
+     *  <p>A Reference represents a loose reference to another resource in the same Project identified by its <code>id</code>. The <code>typeId</code> indicates the type of the referenced resource. Each resource type has its corresponding Reference type, like ChannelReference. A referenced resource can be embedded through Reference Expansion. The expanded reference is the value of an additional <code>obj</code> field then.</p>
+     */
+
+    public ReplicaCartDraftBuilder reference(
+            Function<com.commercetools.api.models.common.ReferenceBuilder, Builder<? extends com.commercetools.api.models.common.Reference>> builder) {
+        this.reference = builder.apply(com.commercetools.api.models.common.ReferenceBuilder.of()).build();
         return this;
     }
 
@@ -45,7 +57,7 @@ public class ReplicaCartDraftBuilder implements Builder<ReplicaCartDraft> {
         return this;
     }
 
-    public java.lang.Object getReference() {
+    public com.commercetools.api.models.common.Reference getReference() {
         return this.reference;
     }
 

--- a/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/cart/ReplicaCartDraftImpl.java
+++ b/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/cart/ReplicaCartDraftImpl.java
@@ -4,9 +4,7 @@ package com.commercetools.api.models.cart;
 import java.time.*;
 import java.util.*;
 
-import com.commercetools.api.models.order.OrderReference;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.*;
 
@@ -22,12 +20,12 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 @Generated(value = "io.vrap.rmf.codegen.rendering.CoreCodeGenerator", comments = "https://github.com/commercetools/rmf-codegen")
 public class ReplicaCartDraftImpl implements ReplicaCartDraft, ModelBase {
 
-    private java.lang.Object reference;
+    private com.commercetools.api.models.common.Reference reference;
 
     private String key;
 
     @JsonCreator
-    ReplicaCartDraftImpl(@JsonProperty("reference") final java.lang.Object reference,
+    ReplicaCartDraftImpl(@JsonProperty("reference") final com.commercetools.api.models.common.Reference reference,
             @JsonProperty("key") final String key) {
         this.reference = reference;
         this.key = key;
@@ -37,10 +35,10 @@ public class ReplicaCartDraftImpl implements ReplicaCartDraft, ModelBase {
     }
 
     /**
-     *
+     *  <p>A Reference represents a loose reference to another resource in the same Project identified by its <code>id</code>. The <code>typeId</code> indicates the type of the referenced resource. Each resource type has its corresponding Reference type, like ChannelReference. A referenced resource can be embedded through Reference Expansion. The expanded reference is the value of an additional <code>obj</code> field then.</p>
      */
 
-    public java.lang.Object getReference() {
+    public com.commercetools.api.models.common.Reference getReference() {
         return this.reference;
     }
 
@@ -52,17 +50,7 @@ public class ReplicaCartDraftImpl implements ReplicaCartDraft, ModelBase {
         return this.key;
     }
 
-    @JsonIgnore
-    public void setReference(final CartReference reference) {
-        this.reference = reference;
-    }
-
-    @JsonIgnore
-    public void setReference(final OrderReference reference) {
-        this.reference = reference;
-    }
-
-    public void setReference(final java.lang.Object reference) {
+    public void setReference(final com.commercetools.api.models.common.Reference reference) {
         this.reference = reference;
     }
 

--- a/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/review/Review.java
+++ b/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/review/Review.java
@@ -9,12 +9,11 @@ import java.util.function.Function;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
-import com.commercetools.api.models.channel.ChannelReference;
 import com.commercetools.api.models.common.BaseResource;
 import com.commercetools.api.models.common.CreatedBy;
 import com.commercetools.api.models.common.LastModifiedBy;
+import com.commercetools.api.models.common.Reference;
 import com.commercetools.api.models.customer.CustomerReference;
-import com.commercetools.api.models.product.ProductReference;
 import com.commercetools.api.models.state.StateReference;
 import com.commercetools.api.models.type.CustomFields;
 import com.fasterxml.jackson.annotation.*;
@@ -130,11 +129,11 @@ public interface Review extends BaseResource, com.commercetools.api.models.Domai
     public String getText();
 
     /**
-     *  <p>Identifies the target of the Review. Can be a Product or a Channel, specified as ProductReference or ChannelReference, respectively.</p>
+     *  <p>A Reference represents a loose reference to another resource in the same Project identified by its <code>id</code>. The <code>typeId</code> indicates the type of the referenced resource. Each resource type has its corresponding Reference type, like ChannelReference. A referenced resource can be embedded through Reference Expansion. The expanded reference is the value of an additional <code>obj</code> field then.</p>
      */
-
+    @Valid
     @JsonProperty("target")
-    public Object getTarget();
+    public Reference getTarget();
 
     /**
      *  <p>Indicates if this Review is taken into account in the ratings statistics of the target. A Review is per default used in the statistics, unless the Review is in a state that does not have the role <code>ReviewIncludedInStatistics</code>. If the role of a State is modified after the calculation of this field, the calculation is not updated.</p>
@@ -195,11 +194,7 @@ public interface Review extends BaseResource, com.commercetools.api.models.Domai
 
     public void setText(final String text);
 
-    public void setTarget(final ProductReference target);
-
-    public void setTarget(final ChannelReference target);
-
-    public void setTarget(final Object target);
+    public void setTarget(final Reference target);
 
     public void setIncludedInStatistics(final Boolean includedInStatistics);
 
@@ -263,6 +258,12 @@ public interface Review extends BaseResource, com.commercetools.api.models.Domai
     public static com.commercetools.api.models.common.ReferenceTypeId referenceTypeId() {
         return com.commercetools.api.models.common.ReferenceTypeId.REVIEW;
     }
+
+    @Deprecated
+    @JsonIgnore
+    public default void setTarget(final Object target) {
+        setTarget((Reference) target);
+    };
 
     public static com.fasterxml.jackson.core.type.TypeReference<Review> typeReference() {
         return new com.fasterxml.jackson.core.type.TypeReference<Review>() {

--- a/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/review/ReviewBuilder.java
+++ b/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/review/ReviewBuilder.java
@@ -61,7 +61,7 @@ public class ReviewBuilder implements Builder<Review> {
     private String text;
 
     @Nullable
-    private java.lang.Object target;
+    private com.commercetools.api.models.common.Reference target;
 
     private Boolean includedInStatistics;
 
@@ -207,11 +207,21 @@ public class ReviewBuilder implements Builder<Review> {
     }
 
     /**
-     *  <p>Identifies the target of the Review. Can be a Product or a Channel, specified as ProductReference or ChannelReference, respectively.</p>
+     *  <p>A Reference represents a loose reference to another resource in the same Project identified by its <code>id</code>. The <code>typeId</code> indicates the type of the referenced resource. Each resource type has its corresponding Reference type, like ChannelReference. A referenced resource can be embedded through Reference Expansion. The expanded reference is the value of an additional <code>obj</code> field then.</p>
      */
 
-    public ReviewBuilder target(@Nullable final java.lang.Object target) {
+    public ReviewBuilder target(@Nullable final com.commercetools.api.models.common.Reference target) {
         this.target = target;
+        return this;
+    }
+
+    /**
+     *  <p>A Reference represents a loose reference to another resource in the same Project identified by its <code>id</code>. The <code>typeId</code> indicates the type of the referenced resource. Each resource type has its corresponding Reference type, like ChannelReference. A referenced resource can be embedded through Reference Expansion. The expanded reference is the value of an additional <code>obj</code> field then.</p>
+     */
+
+    public ReviewBuilder target(
+            Function<com.commercetools.api.models.common.ReferenceBuilder, Builder<? extends com.commercetools.api.models.common.Reference>> builder) {
+        this.target = builder.apply(com.commercetools.api.models.common.ReferenceBuilder.of()).build();
         return this;
     }
 
@@ -347,7 +357,7 @@ public class ReviewBuilder implements Builder<Review> {
     }
 
     @Nullable
-    public java.lang.Object getTarget() {
+    public com.commercetools.api.models.common.Reference getTarget() {
         return this.target;
     }
 

--- a/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/review/ReviewDraft.java
+++ b/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/review/ReviewDraft.java
@@ -7,9 +7,8 @@ import java.util.function.Function;
 
 import javax.validation.Valid;
 
-import com.commercetools.api.models.channel.ChannelResourceIdentifier;
+import com.commercetools.api.models.common.ResourceIdentifier;
 import com.commercetools.api.models.customer.CustomerResourceIdentifier;
-import com.commercetools.api.models.product.ProductResourceIdentifier;
 import com.commercetools.api.models.state.StateResourceIdentifier;
 import com.commercetools.api.models.type.CustomFieldsDraft;
 import com.fasterxml.jackson.annotation.*;
@@ -77,11 +76,12 @@ public interface ReviewDraft extends com.commercetools.api.models.CustomizableDr
     public String getText();
 
     /**
-     *  <p>Identifies the target of the Review. Can be a Product or a Channel, specified as ProductResourceIdentifier or ChannelResourceIdentifier, respectively.</p>
+     *  <p>Draft type to create a Reference or a KeyReference to a resource. Provide either the <code>id</code> or (wherever supported) the <code>key</code> of the resource to reference, but depending on the API endpoint the response returns either a Reference or a KeyReference. For example, the field <code>parent</code> of a CategoryDraft takes a ResourceIdentifier for its value while the value of the corresponding field of a Category is a Reference.</p>
+     *  <p>Each resource type has its corresponding ResourceIdentifier, like ChannelResourceIdentifier.</p>
      */
-
+    @Valid
     @JsonProperty("target")
-    public Object getTarget();
+    public ResourceIdentifier getTarget();
 
     /**
      *  <p>State of the Review. Used for approval processes, see Review approval process for details.</p>
@@ -123,11 +123,7 @@ public interface ReviewDraft extends com.commercetools.api.models.CustomizableDr
 
     public void setText(final String text);
 
-    public void setTarget(final ProductResourceIdentifier target);
-
-    public void setTarget(final ChannelResourceIdentifier target);
-
-    public void setTarget(final Object target);
+    public void setTarget(final ResourceIdentifier target);
 
     public void setState(final StateResourceIdentifier state);
 
@@ -168,6 +164,12 @@ public interface ReviewDraft extends com.commercetools.api.models.CustomizableDr
     default <T> T withReviewDraft(Function<ReviewDraft, T> helper) {
         return helper.apply(this);
     }
+
+    @Deprecated
+    @JsonIgnore
+    public default void setTarget(final Object target) {
+        setTarget((ResourceIdentifier) target);
+    };
 
     public static com.fasterxml.jackson.core.type.TypeReference<ReviewDraft> typeReference() {
         return new com.fasterxml.jackson.core.type.TypeReference<ReviewDraft>() {

--- a/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/review/ReviewDraftBuilder.java
+++ b/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/review/ReviewDraftBuilder.java
@@ -42,7 +42,7 @@ public class ReviewDraftBuilder implements Builder<ReviewDraft> {
     private String text;
 
     @Nullable
-    private java.lang.Object target;
+    private com.commercetools.api.models.common.ResourceIdentifier target;
 
     @Nullable
     private com.commercetools.api.models.state.StateResourceIdentifier state;
@@ -111,11 +111,23 @@ public class ReviewDraftBuilder implements Builder<ReviewDraft> {
     }
 
     /**
-     *  <p>Identifies the target of the Review. Can be a Product or a Channel, specified as ProductResourceIdentifier or ChannelResourceIdentifier, respectively.</p>
+     *  <p>Draft type to create a Reference or a KeyReference to a resource. Provide either the <code>id</code> or (wherever supported) the <code>key</code> of the resource to reference, but depending on the API endpoint the response returns either a Reference or a KeyReference. For example, the field <code>parent</code> of a CategoryDraft takes a ResourceIdentifier for its value while the value of the corresponding field of a Category is a Reference.</p>
+     *  <p>Each resource type has its corresponding ResourceIdentifier, like ChannelResourceIdentifier.</p>
      */
 
-    public ReviewDraftBuilder target(@Nullable final java.lang.Object target) {
+    public ReviewDraftBuilder target(@Nullable final com.commercetools.api.models.common.ResourceIdentifier target) {
         this.target = target;
+        return this;
+    }
+
+    /**
+     *  <p>Draft type to create a Reference or a KeyReference to a resource. Provide either the <code>id</code> or (wherever supported) the <code>key</code> of the resource to reference, but depending on the API endpoint the response returns either a Reference or a KeyReference. For example, the field <code>parent</code> of a CategoryDraft takes a ResourceIdentifier for its value while the value of the corresponding field of a Category is a Reference.</p>
+     *  <p>Each resource type has its corresponding ResourceIdentifier, like ChannelResourceIdentifier.</p>
+     */
+
+    public ReviewDraftBuilder target(
+            Function<com.commercetools.api.models.common.ResourceIdentifierBuilder, Builder<? extends com.commercetools.api.models.common.ResourceIdentifier>> builder) {
+        this.target = builder.apply(com.commercetools.api.models.common.ResourceIdentifierBuilder.of()).build();
         return this;
     }
 
@@ -218,7 +230,7 @@ public class ReviewDraftBuilder implements Builder<ReviewDraft> {
     }
 
     @Nullable
-    public java.lang.Object getTarget() {
+    public com.commercetools.api.models.common.ResourceIdentifier getTarget() {
         return this.target;
     }
 

--- a/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/review/ReviewDraftImpl.java
+++ b/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/review/ReviewDraftImpl.java
@@ -4,10 +4,7 @@ package com.commercetools.api.models.review;
 import java.time.*;
 import java.util.*;
 
-import com.commercetools.api.models.channel.ChannelResourceIdentifier;
-import com.commercetools.api.models.product.ProductResourceIdentifier;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.*;
 
@@ -35,7 +32,7 @@ public class ReviewDraftImpl implements ReviewDraft, ModelBase {
 
     private String text;
 
-    private java.lang.Object target;
+    private com.commercetools.api.models.common.ResourceIdentifier target;
 
     private com.commercetools.api.models.state.StateResourceIdentifier state;
 
@@ -49,7 +46,8 @@ public class ReviewDraftImpl implements ReviewDraft, ModelBase {
     ReviewDraftImpl(@JsonProperty("key") final String key,
             @JsonProperty("uniquenessValue") final String uniquenessValue, @JsonProperty("locale") final String locale,
             @JsonProperty("authorName") final String authorName, @JsonProperty("title") final String title,
-            @JsonProperty("text") final String text, @JsonProperty("target") final java.lang.Object target,
+            @JsonProperty("text") final String text,
+            @JsonProperty("target") final com.commercetools.api.models.common.ResourceIdentifier target,
             @JsonProperty("state") final com.commercetools.api.models.state.StateResourceIdentifier state,
             @JsonProperty("rating") final Integer rating,
             @JsonProperty("customer") final com.commercetools.api.models.customer.CustomerResourceIdentifier customer,
@@ -119,10 +117,11 @@ public class ReviewDraftImpl implements ReviewDraft, ModelBase {
     }
 
     /**
-     *  <p>Identifies the target of the Review. Can be a Product or a Channel, specified as ProductResourceIdentifier or ChannelResourceIdentifier, respectively.</p>
+     *  <p>Draft type to create a Reference or a KeyReference to a resource. Provide either the <code>id</code> or (wherever supported) the <code>key</code> of the resource to reference, but depending on the API endpoint the response returns either a Reference or a KeyReference. For example, the field <code>parent</code> of a CategoryDraft takes a ResourceIdentifier for its value while the value of the corresponding field of a Category is a Reference.</p>
+     *  <p>Each resource type has its corresponding ResourceIdentifier, like ChannelResourceIdentifier.</p>
      */
 
-    public java.lang.Object getTarget() {
+    public com.commercetools.api.models.common.ResourceIdentifier getTarget() {
         return this.target;
     }
 
@@ -182,17 +181,7 @@ public class ReviewDraftImpl implements ReviewDraft, ModelBase {
         this.text = text;
     }
 
-    @JsonIgnore
-    public void setTarget(final ProductResourceIdentifier target) {
-        this.target = target;
-    }
-
-    @JsonIgnore
-    public void setTarget(final ChannelResourceIdentifier target) {
-        this.target = target;
-    }
-
-    public void setTarget(final java.lang.Object target) {
+    public void setTarget(final com.commercetools.api.models.common.ResourceIdentifier target) {
         this.target = target;
     }
 

--- a/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/review/ReviewImpl.java
+++ b/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/review/ReviewImpl.java
@@ -4,10 +4,7 @@ package com.commercetools.api.models.review;
 import java.time.*;
 import java.util.*;
 
-import com.commercetools.api.models.channel.ChannelReference;
-import com.commercetools.api.models.product.ProductReference;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.*;
 
@@ -47,7 +44,7 @@ public class ReviewImpl implements Review, ModelBase {
 
     private String text;
 
-    private java.lang.Object target;
+    private com.commercetools.api.models.common.Reference target;
 
     private Boolean includedInStatistics;
 
@@ -68,7 +65,7 @@ public class ReviewImpl implements Review, ModelBase {
             @JsonProperty("key") final String key, @JsonProperty("uniquenessValue") final String uniquenessValue,
             @JsonProperty("locale") final String locale, @JsonProperty("authorName") final String authorName,
             @JsonProperty("title") final String title, @JsonProperty("text") final String text,
-            @JsonProperty("target") final java.lang.Object target,
+            @JsonProperty("target") final com.commercetools.api.models.common.Reference target,
             @JsonProperty("includedInStatistics") final Boolean includedInStatistics,
             @JsonProperty("rating") final Integer rating,
             @JsonProperty("state") final com.commercetools.api.models.state.StateReference state,
@@ -194,10 +191,10 @@ public class ReviewImpl implements Review, ModelBase {
     }
 
     /**
-     *  <p>Identifies the target of the Review. Can be a Product or a Channel, specified as ProductReference or ChannelReference, respectively.</p>
+     *  <p>A Reference represents a loose reference to another resource in the same Project identified by its <code>id</code>. The <code>typeId</code> indicates the type of the referenced resource. Each resource type has its corresponding Reference type, like ChannelReference. A referenced resource can be embedded through Reference Expansion. The expanded reference is the value of an additional <code>obj</code> field then.</p>
      */
 
-    public java.lang.Object getTarget() {
+    public com.commercetools.api.models.common.Reference getTarget() {
         return this.target;
     }
 
@@ -289,17 +286,7 @@ public class ReviewImpl implements Review, ModelBase {
         this.text = text;
     }
 
-    @JsonIgnore
-    public void setTarget(final ProductReference target) {
-        this.target = target;
-    }
-
-    @JsonIgnore
-    public void setTarget(final ChannelReference target) {
-        this.target = target;
-    }
-
-    public void setTarget(final java.lang.Object target) {
+    public void setTarget(final com.commercetools.api.models.common.Reference target) {
         this.target = target;
     }
 

--- a/commercetools/commercetools-sdk-java-api/src/main/java/com/commercetools/api/json/ApiModule.java
+++ b/commercetools/commercetools-sdk-java-api/src/main/java/com/commercetools/api/json/ApiModule.java
@@ -3,10 +3,8 @@ package com.commercetools.api.json;
 
 import java.util.Optional;
 
-import com.commercetools.api.models.cart.ReplicaCartDraft;
 import com.commercetools.api.models.common.*;
 import com.commercetools.api.models.product.AttributeImpl;
-import com.commercetools.api.models.review.Review;
 import com.commercetools.api.models.type.FieldContainerImpl;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
@@ -27,7 +25,5 @@ public class ApiModule extends SimpleModule {
                         .orElse(System.getProperty(ApiModuleOptions.DESERIALIZE_DATE_FIELD_AS_STRING)));
         addDeserializer(AttributeImpl.class, new AtrributeDeserializer(attributeAsDateString));
         addDeserializer(FieldContainerImpl.class, new CustomFieldDeserializer(customFieldAsDateString));
-        setMixInAnnotation(Review.class, ReviewMixin.class);
-        setMixInAnnotation(ReplicaCartDraft.class, ReplicaCartDraftMixin.class);
     }
 }

--- a/commercetools/commercetools-sdk-java-api/src/main/java/com/commercetools/api/json/ReplicaCartDraftMixin.java
+++ b/commercetools/commercetools-sdk-java-api/src/main/java/com/commercetools/api/json/ReplicaCartDraftMixin.java
@@ -6,6 +6,7 @@ import com.commercetools.api.models.order.OrderReference;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+@Deprecated
 public interface ReplicaCartDraftMixin {
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "typeId", visible = true)

--- a/commercetools/commercetools-sdk-java-api/src/main/java/com/commercetools/api/json/ReviewMixin.java
+++ b/commercetools/commercetools-sdk-java-api/src/main/java/com/commercetools/api/json/ReviewMixin.java
@@ -6,6 +6,7 @@ import com.commercetools.api.models.product.ProductReference;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+@Deprecated
 public interface ReviewMixin {
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "typeId", visible = true)

--- a/commercetools/commercetools-sdk-java-api/src/test/java/com/commercetools/ReplicateTest.java
+++ b/commercetools/commercetools-sdk-java-api/src/test/java/com/commercetools/ReplicateTest.java
@@ -1,0 +1,35 @@
+
+package com.commercetools;
+
+import com.commercetools.api.models.cart.CartReference;
+import com.commercetools.api.models.cart.ReplicaCartDraft;
+import com.commercetools.api.models.order.OrderReference;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ReplicateTest {
+    @Test
+    public void replicateCart() {
+        ReplicaCartDraft draft = ReplicaCartDraft.of();
+        draft.setReference(CartReference.of());
+
+        Assertions.assertThat(draft.getReference()).isInstanceOf(CartReference.class);
+    }
+
+    @Test
+    public void replicateOrder() {
+        ReplicaCartDraft draft = ReplicaCartDraft.of();
+        draft.setReference(OrderReference.of());
+
+        Assertions.assertThat(draft.getReference()).isInstanceOf(OrderReference.class);
+    }
+
+    @Test
+    public void replicateOrderObject() {
+        ReplicaCartDraft draft = ReplicaCartDraft.of();
+        draft.setReference((Object) OrderReference.of());
+
+        Assertions.assertThat(draft.getReference()).isInstanceOf(OrderReference.class);
+    }
+}

--- a/commercetools/commercetools-sdk-java-api/src/test/java/com/commercetools/ReviewTest.java
+++ b/commercetools/commercetools-sdk-java-api/src/test/java/com/commercetools/ReviewTest.java
@@ -7,11 +7,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 
 import com.commercetools.api.models.channel.ChannelReference;
+import com.commercetools.api.models.channel.ChannelResourceIdentifier;
 import com.commercetools.api.models.product.ProductReference;
+import com.commercetools.api.models.product.ProductResourceIdentifier;
 import com.commercetools.api.models.review.Review;
+import com.commercetools.api.models.review.ReviewDraft;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 import io.vrap.rmf.base.client.utils.json.JsonUtils;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ReviewTest {
@@ -30,4 +35,97 @@ public class ReviewTest {
         assertThat(review.getTarget()).isInstanceOf(ChannelReference.class);
     }
 
+    @Test
+    public void setProductReview() {
+        Review review = Review.of();
+        review.setTarget(ProductReference.of());
+
+        assertThat(review.getTarget()).isInstanceOf(ProductReference.class);
+    }
+
+    @Test
+    public void setChannelReview() {
+        Review review = Review.of();
+        review.setTarget(ChannelReference.of());
+
+        assertThat(review.getTarget()).isInstanceOf(ChannelReference.class);
+    }
+
+    @Test
+    public void setObjectReview() {
+        Review review = Review.of();
+        review.setTarget((Object) ProductReference.of());
+
+        assertThat(review.getTarget()).isInstanceOf(ProductReference.class);
+    }
+
+    @Test
+    public void setInvalidObjectReview() {
+        Review review = Review.of();
+        Assertions.assertThatThrownBy(() -> {
+            review.setTarget(ChannelResourceIdentifier.of());
+        }).isInstanceOfAny(AssertionError.class, ClassCastException.class);
+    }
+
+    @Test
+    public void productReviewDraft() throws IOException {
+        ReviewDraft review = JsonUtils.fromJsonString(stringFromResource("product-review.json"), ReviewDraft.class);
+
+        assertThat(review.getTarget()).isInstanceOf(ProductResourceIdentifier.class);
+    }
+
+    @Test
+    public void channelReviewDraft() throws IOException {
+        ReviewDraft review = JsonUtils.fromJsonString(stringFromResource("channel-review.json"), ReviewDraft.class);
+
+        assertThat(review.getTarget()).isInstanceOf(ChannelResourceIdentifier.class);
+    }
+
+    @Test
+    public void setProductReviewDraft() {
+        ReviewDraft review = ReviewDraft.of();
+        review.setTarget(ProductResourceIdentifier.of());
+
+        assertThat(review.getTarget()).isInstanceOf(ProductResourceIdentifier.class);
+    }
+
+    @Test
+    public void setChannelReviewDraft() {
+        ReviewDraft review = ReviewDraft.of();
+        review.setTarget(ChannelResourceIdentifier.of());
+
+        assertThat(review.getTarget()).isInstanceOf(ChannelResourceIdentifier.class);
+    }
+
+    @Test
+    public void setObjectReviewDraft() {
+        ReviewDraft review = ReviewDraft.of();
+        review.setTarget((Object) ProductResourceIdentifier.of());
+
+        assertThat(review.getTarget()).isInstanceOf(ProductResourceIdentifier.class);
+    }
+
+    @Test
+    public void setInvalidObjectReviewDraft() {
+        ReviewDraft review = ReviewDraft.of();
+        Assertions.assertThatThrownBy(() -> {
+            review.setTarget((Object) ChannelReference.of());
+        }).isInstanceOfAny(AssertionError.class, ClassCastException.class);
+    }
+
+    @Test
+    public void serializeDraft() throws JsonProcessingException {
+        ReviewDraft draft = ReviewDraft.of();
+        draft.setTarget(ProductResourceIdentifier.of());
+        String s = JsonUtils.toJsonString(draft);
+        Assertions.assertThat(s).isEqualTo("{\"target\":{\"typeId\":\"product\"}}");
+    }
+
+    @Test
+    public void serialize() throws JsonProcessingException {
+        Review review = Review.of();
+        review.setTarget(ProductReference.of());
+        String s = JsonUtils.toJsonString(review);
+        Assertions.assertThat(s).isEqualTo("{\"target\":{\"typeId\":\"product\"}}");
+    }
 }


### PR DESCRIPTION
- field `target` of `Review` changed to `Reference`
- field `target` of `ReviewDraft` changed to `ResourceIdentifier`
- field `reference` of `ReplicaCartDraft` changed to type `Reference`

- deprecated use of `setTarget(Object)` for `Review` and `ReviewDraft`
- deprecated use of `setReference(Object)` for `ReplicaCartDraft`
- deprecated `ReviewMixin`
- deprecated `ReplicaCartDraftMixin`

- [ ] Changeset added

### Features

### Fixes

### Breaking changes

