### PR TITLE
Add WithKey interface to AttributePlainEnumValue and AttributeLocalizedEnumValue

### DIFF
--- a/api-java-mixin.raml
+++ b/api-java-mixin.raml
@@ -33,6 +33,10 @@ types:
     (java-extends): 'com.commercetools.api.models.WithKey'
   AssetDraft:
     (java-extends): 'com.commercetools.api.models.CustomizableDraft<AssetDraft>, com.commercetools.api.models.WithKey'
+  AttributePlainEnumValue:
+    (java-extends): 'com.commercetools.api.models.WithKey'
+  AttributeLocalizedEnumValue:
+    (java-extends): 'com.commercetools.api.models.WithKey'
   LocalizedString:
     (java-extends): 'com.commercetools.api.models.common.LocalizedStringUtil'
   ReplicaCartDraft:

--- a/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/product_type/AttributeLocalizedEnumValue.java
+++ b/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/product_type/AttributeLocalizedEnumValue.java
@@ -9,6 +9,7 @@ import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import com.commercetools.api.models.WithKey;
 import com.commercetools.api.models.common.LocalizedString;
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.*;
@@ -31,7 +32,7 @@ import io.vrap.rmf.base.client.utils.Generated;
  */
 @Generated(value = "io.vrap.rmf.codegen.rendering.CoreCodeGenerator", comments = "https://github.com/commercetools/rmf-codegen")
 @JsonDeserialize(as = AttributeLocalizedEnumValueImpl.class)
-public interface AttributeLocalizedEnumValue {
+public interface AttributeLocalizedEnumValue extends WithKey {
 
     /**
      *  <p>Key of the value used as a programmatic identifier, for example in facets &amp; filters.</p>

--- a/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/product_type/AttributePlainEnumValue.java
+++ b/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/product_type/AttributePlainEnumValue.java
@@ -8,6 +8,7 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
+import com.commercetools.api.models.WithKey;
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.*;
 
@@ -29,7 +30,7 @@ import io.vrap.rmf.base.client.utils.Generated;
  */
 @Generated(value = "io.vrap.rmf.codegen.rendering.CoreCodeGenerator", comments = "https://github.com/commercetools/rmf-codegen")
 @JsonDeserialize(as = AttributePlainEnumValueImpl.class)
-public interface AttributePlainEnumValue {
+public interface AttributePlainEnumValue extends WithKey {
 
     /**
      *  <p>Key of the value used as a programmatic identifier, for example in facets &amp; filters.</p>


### PR DESCRIPTION
I added WithKey interface to AttributePlainEnumValue and AttributeLocalizedEnumValue because the classes were missing them. This caused issue when trying to use generics with these classes.
