### PR TITLE
Add withkey interface to CustomFieldLocalizedEnumValue and CustomFieldEnumValue

### DIFF
--- a/api-java-mixin.raml
+++ b/api-java-mixin.raml
@@ -156,6 +156,10 @@ types:
       public static CustomerGroupSetCustomFieldAction ofUnset(final String name) {
           return CustomerGroupSetCustomFieldActionBuilder.of().name(name).build();
       }
+  CustomFieldEnumValue:
+      (java-extends): 'com.commercetools.api.models.WithKey'
+  CustomFieldLocalizedEnumValue:
+      (java-extends): 'com.commercetools.api.models.WithKey'
   DiscountCode:
     (java-extends): 'DiscountCodeMixin, com.commercetools.api.models.DomainResource<DiscountCode>, com.commercetools.api.models.Referencable<DiscountCode>, com.commercetools.api.models.ResourceIdentifiable<DiscountCode>, com.commercetools.api.models.Customizable<DiscountCode>'
     (java-mixin): |

--- a/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/type/CustomFieldEnumValue.java
+++ b/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/type/CustomFieldEnumValue.java
@@ -8,6 +8,7 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
+import com.commercetools.api.models.WithKey;
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.*;
 
@@ -29,7 +30,7 @@ import io.vrap.rmf.base.client.utils.Generated;
  */
 @Generated(value = "io.vrap.rmf.codegen.rendering.CoreCodeGenerator", comments = "https://github.com/commercetools/rmf-codegen")
 @JsonDeserialize(as = CustomFieldEnumValueImpl.class)
-public interface CustomFieldEnumValue {
+public interface CustomFieldEnumValue extends WithKey {
 
     /**
      *  <p>Key of the value used as a programmatic identifier.</p>

--- a/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/type/CustomFieldLocalizedEnumValue.java
+++ b/commercetools/commercetools-sdk-java-api/src/main/java-generated/com/commercetools/api/models/type/CustomFieldLocalizedEnumValue.java
@@ -9,6 +9,7 @@ import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import com.commercetools.api.models.WithKey;
 import com.commercetools.api.models.common.LocalizedString;
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.*;
@@ -31,7 +32,7 @@ import io.vrap.rmf.base.client.utils.Generated;
  */
 @Generated(value = "io.vrap.rmf.codegen.rendering.CoreCodeGenerator", comments = "https://github.com/commercetools/rmf-codegen")
 @JsonDeserialize(as = CustomFieldLocalizedEnumValueImpl.class)
-public interface CustomFieldLocalizedEnumValue {
+public interface CustomFieldLocalizedEnumValue extends WithKey {
 
     /**
      *  <p>Key of the value used as a programmatic identifier.</p>


### PR DESCRIPTION
Added `WithKey` interface to these classes because it was missing and therefore caused issues to use generics with them.

