### PR TITLE
Add option to turn off histogram in opentelemetry

### DIFF
--- a/commercetools/commercetools-monitoring-opentelemetry/src/main/java/com/commercetools/monitoring/opentelemetry/OpenTelemetryMiddleware.java
+++ b/commercetools/commercetools-monitoring-opentelemetry/src/main/java/com/commercetools/monitoring/opentelemetry/OpenTelemetryMiddleware.java
@@ -68,7 +68,8 @@ public class OpenTelemetryMiddleware implements TelemetryMiddleware {
                 builder.put(OpenTelemetryInfo.SERVER_PORT, request.getUri().getPort());
             }
             Attributes attributes = builder.build();
-            Optional.ofNullable(histogram).ifPresent(h -> h.record(Duration.between(start, Instant.now()).toMillis(), attributes));
+            Optional.ofNullable(histogram)
+                    .ifPresent(h -> h.record(Duration.between(start, Instant.now()).toMillis(), attributes));
             requestCounter.add(1, attributes);
             if (response.getStatusCode() >= 400) {
                 errorCounter.add(1, attributes);


### PR DESCRIPTION
This option is for cases like dynatrace where histogram is not supported: https://docs.dynatrace.com/docs/extend-dynatrace/opentelemetry/overview/metrics#dynatrace-mapping