### PR TITLE
feat: always deserialize to long for jsonutils

### DIFF
--- a/rmf/rmf-java-base/src/main/java/io/vrap/rmf/base/client/utils/json/JsonUtils.java
+++ b/rmf/rmf-java-base/src/main/java/io/vrap/rmf/base/client/utils/json/JsonUtils.java
@@ -63,6 +63,7 @@ public class JsonUtils {
                 .serializationInclusion(JsonInclude.Include.NON_NULL) //ignore null fields
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+                .configure(DeserializationFeature.USE_LONG_FOR_INTS, true)
                 .configure(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES, false)
                 .build();
     }


### PR DESCRIPTION
When using `JsonUtils.toJsonNode()` the numbers got converted to `IntNode` containing integers. However, when the same attribute comes from CT, its value is deserialized as Long. This make it hard to compare if the numbers are equal or not. This change ensures that numbers are always converted to long.