### PR TITLE
Optimize HTTP client performance: eliminate redundant header...

### DIFF
--- a/commercetools/commercetools-apachehttp-client/src/main/java/com/commercetools/http/apachehttp/CtApacheHttpClient.java
+++ b/commercetools/commercetools-apachehttp-client/src/main/java/com/commercetools/http/apachehttp/CtApacheHttpClient.java
@@ -188,12 +188,9 @@ public class CtApacheHttpClient extends HttpClientBase {
         if (httpRequest.getBody() != null) {
             //default media type is JSON, if other media type is set as a header, use it
             ContentType mediaType = ContentType.APPLICATION_JSON.withCharset(StandardCharsets.UTF_8);
-            if (httpRequest.getHeaders()
-                    .getHeaders()
-                    .stream()
-                    .anyMatch(s -> s.getKey().equalsIgnoreCase(ApiHttpHeaders.CONTENT_TYPE))) {
-                mediaType = ContentType
-                        .parse(Objects.requireNonNull(httpRequest.getHeaders().getFirst(ApiHttpHeaders.CONTENT_TYPE)));
+            final String contentTypeValue = httpRequest.getHeaders().getFirst(ApiHttpHeaders.CONTENT_TYPE);
+            if (contentTypeValue != null) {
+                mediaType = ContentType.parse(contentTypeValue);
             }
 
             builder.setEntity(httpRequest.getBody(), mediaType);
@@ -210,14 +207,12 @@ public class CtApacheHttpClient extends HttpClientBase {
     }
 
     private static ApiHttpResponse<byte[]> toResponse(final SimpleHttpResponse response) {
-        final Map<String, List<Header>> apacheHeaders = Arrays.stream(response.getHeaders())
-                .collect(Collectors.groupingBy(Header::getName));
-
-        final ApiHttpHeaders apiHttpHeaders = new ApiHttpHeaders(apacheHeaders.entrySet()
-                .stream()
-                .flatMap(
-                    e -> e.getValue().stream().map(value -> ApiHttpHeaders.headerEntry(e.getKey(), value.getValue())))
-                .collect(Collectors.toList()));
+        final Header[] responseHeaders = response.getHeaders();
+        final List<Map.Entry<String, String>> headerList = new ArrayList<>(responseHeaders.length);
+        for (Header header : responseHeaders) {
+            headerList.add(ApiHttpHeaders.headerEntry(header.getName(), header.getValue()));
+        }
+        final ApiHttpHeaders apiHttpHeaders = new ApiHttpHeaders(headerList);
 
         final byte[] bodyNullable = Optional.ofNullable(response.getBody()).map((SimpleBody entity) -> {
             try {

--- a/commercetools/commercetools-async-http-client/src/main/java/com/commercetools/http/asynchttp/CtAsyncHttpClient.java
+++ b/commercetools/commercetools-async-http-client/src/main/java/com/commercetools/http/asynchttp/CtAsyncHttpClient.java
@@ -161,12 +161,9 @@ public class CtAsyncHttpClient extends HttpClientBase implements VrapHttpClient,
         Optional.ofNullable(request.getBody()).ifPresent(body -> {
             builder.setBody(body);
             AsciiString mediaType = HttpHeaderValues.APPLICATION_JSON;
-            if (request.getHeaders()
-                    .getHeaders()
-                    .stream()
-                    .anyMatch(s -> s.getKey().equalsIgnoreCase(ApiHttpHeaders.CONTENT_TYPE))) {
-                mediaType = AsciiString
-                        .of(Objects.requireNonNull(request.getHeaders().getFirst(ApiHttpHeaders.CONTENT_TYPE)));
+            final String contentTypeValue = request.getHeaders().getFirst(ApiHttpHeaders.CONTENT_TYPE);
+            if (contentTypeValue != null) {
+                mediaType = AsciiString.of(contentTypeValue);
             }
             builder.setHeader(ApiHttpHeaders.CONTENT_TYPE, mediaType);
         });

--- a/commercetools/commercetools-javanet-client/src/main/java/com/commercetools/http/javanet/CtJavaNetHttpClient.java
+++ b/commercetools/commercetools-javanet-client/src/main/java/com/commercetools/http/javanet/CtJavaNetHttpClient.java
@@ -69,11 +69,9 @@ public class CtJavaNetHttpClient extends HttpClientBase {
 
         if (httpRequest.getBody() != null) {
             String mediaType = APPLICATION_JSON;
-            if (httpRequest.getHeaders()
-                    .getHeaders()
-                    .stream()
-                    .anyMatch(s -> s.getKey().equalsIgnoreCase(ApiHttpHeaders.CONTENT_TYPE))) {
-                mediaType = httpRequest.getHeaders().getFirst(ApiHttpHeaders.CONTENT_TYPE);
+            final String contentTypeValue = httpRequest.getHeaders().getFirst(ApiHttpHeaders.CONTENT_TYPE);
+            if (contentTypeValue != null) {
+                mediaType = contentTypeValue;
             }
             builder.setHeader(ApiHttpHeaders.CONTENT_TYPE, mediaType);
 

--- a/commercetools/commercetools-okhttp-client3/src/main/java/com/commercetools/http/okhttp3/CtOkHttp3Client.java
+++ b/commercetools/commercetools-okhttp-client3/src/main/java/com/commercetools/http/okhttp3/CtOkHttp3Client.java
@@ -108,12 +108,12 @@ public class CtOkHttp3Client extends HttpClientBase {
     }
 
     static ApiHttpResponse<byte[]> toResponse(final okhttp3.Response response) {
-        final ApiHttpHeaders apiHttpHeaders = new ApiHttpHeaders(response.headers()
-                .toMultimap()
-                .entrySet()
-                .stream()
-                .flatMap(e -> e.getValue().stream().map(value -> ApiHttpHeaders.headerEntry(e.getKey(), value)))
-                .collect(Collectors.toList()));
+        final okhttp3.Headers responseHeaders = response.headers();
+        final List<Map.Entry<String, String>> headerList = new ArrayList<>(responseHeaders.size());
+        for (int i = 0; i < responseHeaders.size(); i++) {
+            headerList.add(ApiHttpHeaders.headerEntry(responseHeaders.name(i), responseHeaders.value(i)));
+        }
+        final ApiHttpHeaders apiHttpHeaders = new ApiHttpHeaders(headerList);
 
         final ApiHttpResponse<byte[]> apiHttpResponse = new ApiHttpResponse<>(response.code(), apiHttpHeaders,
             Optional.ofNullable(response.body())
@@ -141,12 +141,9 @@ public class CtOkHttp3Client extends HttpClientBase {
 
         //default media type is JSON, if other media type is set as a header, use it
         okhttp3.MediaType mediaType = JSON;
-        if (apiHttpRequest.getHeaders()
-                .getHeaders()
-                .stream()
-                .anyMatch(s -> s.getKey().equalsIgnoreCase(CONTENT_TYPE))) {
-            mediaType = okhttp3.MediaType
-                    .parse(Objects.requireNonNull(apiHttpRequest.getHeaders().getFirst(ApiHttpHeaders.CONTENT_TYPE)));
+        final String contentTypeValue = apiHttpRequest.getHeaders().getFirst(ApiHttpHeaders.CONTENT_TYPE);
+        if (contentTypeValue != null) {
+            mediaType = okhttp3.MediaType.parse(contentTypeValue);
         }
 
         final okhttp3.RequestBody body = apiHttpRequest.getBody() == null ? null

--- a/commercetools/commercetools-okhttp-client4/src/main/java/com/commercetools/http/okhttp4/CtOkHttp4Client.java
+++ b/commercetools/commercetools-okhttp-client4/src/main/java/com/commercetools/http/okhttp4/CtOkHttp4Client.java
@@ -108,12 +108,12 @@ public class CtOkHttp4Client extends HttpClientBase {
     }
 
     static ApiHttpResponse<byte[]> toResponse(final okhttp3.Response response) {
-        final ApiHttpHeaders apiHttpHeaders = new ApiHttpHeaders(response.headers()
-                .toMultimap()
-                .entrySet()
-                .stream()
-                .flatMap(e -> e.getValue().stream().map(value -> ApiHttpHeaders.headerEntry(e.getKey(), value)))
-                .collect(Collectors.toList()));
+        final okhttp3.Headers responseHeaders = response.headers();
+        final List<Map.Entry<String, String>> headerList = new ArrayList<>(responseHeaders.size());
+        for (int i = 0; i < responseHeaders.size(); i++) {
+            headerList.add(ApiHttpHeaders.headerEntry(responseHeaders.name(i), responseHeaders.value(i)));
+        }
+        final ApiHttpHeaders apiHttpHeaders = new ApiHttpHeaders(headerList);
 
         final ApiHttpResponse<byte[]> apiHttpResponse = new ApiHttpResponse<>(response.code(), apiHttpHeaders,
             Optional.ofNullable(response.body())
@@ -141,12 +141,9 @@ public class CtOkHttp4Client extends HttpClientBase {
 
         //default media type is JSON, if other media type is set as a header, use it
         okhttp3.MediaType mediaType = JSON;
-        if (apiHttpRequest.getHeaders()
-                .getHeaders()
-                .stream()
-                .anyMatch(s -> s.getKey().equalsIgnoreCase(CONTENT_TYPE))) {
-            mediaType = okhttp3.MediaType
-                    .get(Objects.requireNonNull(apiHttpRequest.getHeaders().getFirst(ApiHttpHeaders.CONTENT_TYPE)));
+        final String contentTypeValue = apiHttpRequest.getHeaders().getFirst(ApiHttpHeaders.CONTENT_TYPE);
+        if (contentTypeValue != null) {
+            mediaType = okhttp3.MediaType.get(contentTypeValue);
         }
 
         try {

--- a/commercetools/commercetools-okhttp-client5/src/main/java/com/commercetools/http/okhttp5/CtOkHttp5Client.java
+++ b/commercetools/commercetools-okhttp-client5/src/main/java/com/commercetools/http/okhttp5/CtOkHttp5Client.java
@@ -108,12 +108,12 @@ public class CtOkHttp5Client extends HttpClientBase {
     }
 
     static ApiHttpResponse<byte[]> toResponse(final okhttp3.Response response) {
-        final ApiHttpHeaders apiHttpHeaders = new ApiHttpHeaders(response.headers()
-                .toMultimap()
-                .entrySet()
-                .stream()
-                .flatMap(e -> e.getValue().stream().map(value -> ApiHttpHeaders.headerEntry(e.getKey(), value)))
-                .collect(Collectors.toList()));
+        final okhttp3.Headers responseHeaders = response.headers();
+        final List<Map.Entry<String, String>> headerList = new ArrayList<>(responseHeaders.size());
+        for (int i = 0; i < responseHeaders.size(); i++) {
+            headerList.add(ApiHttpHeaders.headerEntry(responseHeaders.name(i), responseHeaders.value(i)));
+        }
+        final ApiHttpHeaders apiHttpHeaders = new ApiHttpHeaders(headerList);
 
         final ApiHttpResponse<byte[]> apiHttpResponse = new ApiHttpResponse<>(response.code(), apiHttpHeaders,
             Optional.ofNullable(response.body())
@@ -141,12 +141,9 @@ public class CtOkHttp5Client extends HttpClientBase {
 
         //default media type is JSON, if other media type is set as a header, use it
         okhttp3.MediaType mediaType = JSON;
-        if (apiHttpRequest.getHeaders()
-                .getHeaders()
-                .stream()
-                .anyMatch(s -> s.getKey().equalsIgnoreCase(CONTENT_TYPE))) {
-            mediaType = okhttp3.MediaType
-                    .get(Objects.requireNonNull(apiHttpRequest.getHeaders().getFirst(ApiHttpHeaders.CONTENT_TYPE)));
+        final String contentTypeValue = apiHttpRequest.getHeaders().getFirst(ApiHttpHeaders.CONTENT_TYPE);
+        if (contentTypeValue != null) {
+            mediaType = okhttp3.MediaType.get(contentTypeValue);
         }
 
         try {

--- a/commercetools/commercetools-reactornetty-client/src/main/java/com/commercetools/http/netty/CtNettyHttpClient.java
+++ b/commercetools/commercetools-reactornetty-client/src/main/java/com/commercetools/http/netty/CtNettyHttpClient.java
@@ -144,12 +144,9 @@ public class CtNettyHttpClient extends HttpClientBase {
             });
 
             AsciiString mediaType = HttpHeaderValues.APPLICATION_JSON;
-            if (httpRequest.getHeaders()
-                    .getHeaders()
-                    .stream()
-                    .anyMatch(s -> s.getKey().equalsIgnoreCase(ApiHttpHeaders.CONTENT_TYPE))) {
-                mediaType = AsciiString
-                        .of(Objects.requireNonNull(httpRequest.getHeaders().getFirst(ApiHttpHeaders.CONTENT_TYPE)));
+            final String contentTypeValue = httpRequest.getHeaders().getFirst(ApiHttpHeaders.CONTENT_TYPE);
+            if (contentTypeValue != null) {
+                mediaType = AsciiString.of(contentTypeValue);
             }
             nettyRequest.requestHeaders().set(ApiHttpHeaders.CONTENT_TYPE, mediaType);
 

--- a/rmf/rmf-java-base/src/main/java/io/vrap/rmf/base/client/oauth2/BaseAuthTokenSupplier.java
+++ b/rmf/rmf-java-base/src/main/java/io/vrap/rmf/base/client/oauth2/BaseAuthTokenSupplier.java
@@ -31,8 +31,8 @@ public abstract class BaseAuthTokenSupplier extends AutoCloseableService impleme
     @Override
     public CompletableFuture<AuthenticationToken> getToken() {
         return vrapHttpClient.execute(apiHttpRequest).whenComplete((response, throwable) -> {
-            logger.info(() -> String.format("%s %s %s", apiHttpRequest.getMethod().name(), apiHttpRequest.getUri(),
-                response.getStatusCode()));
+            logger.info(() -> apiHttpRequest.getMethod().name() + " " + apiHttpRequest.getUri() + " "
+                + response.getStatusCode());
             if (throwable != null) {
                 logger.error(() -> response, throwable);
             }
@@ -43,13 +43,14 @@ public abstract class BaseAuthTokenSupplier extends AutoCloseableService impleme
             if (apiHttpResponse.getStatusCode() < 200 || apiHttpResponse.getStatusCode() > 299) {
                 if (apiHttpResponse.getStatusCode() == 405) {
                     throw new CompletionException(new AuthException(apiHttpResponse.getStatusCode(),
-                        new String(apiHttpResponse.getBody()), apiHttpRequest.getHeaders(),
+                        new String(apiHttpResponse.getBody(), StandardCharsets.UTF_8), apiHttpRequest.getHeaders(),
                         apiHttpResponse.getMessage()
                                 + " : auth token URI may be incorrect e.g. https://auth.europe-west1.gcp.commercetools.com/oauth/token",
                         apiHttpResponse));
                 }
                 throw new CompletionException(
-                    new AuthException(apiHttpResponse.getStatusCode(), new String(apiHttpResponse.getBody()),
+                    new AuthException(apiHttpResponse.getStatusCode(),
+                        new String(apiHttpResponse.getBody(), StandardCharsets.UTF_8),
                         apiHttpRequest.getHeaders(), apiHttpResponse.getMessage(), apiHttpResponse));
             }
             return apiHttpResponse;

--- a/rmf/rmf-java-base/src/main/java/io/vrap/rmf/base/client/utils/CompletableFutureUtils.java
+++ b/rmf/rmf-java-base/src/main/java/io/vrap/rmf/base/client/utils/CompletableFutureUtils.java
@@ -288,7 +288,7 @@ public final class CompletableFutureUtils {
         final List<CompletableFuture<T>> futureList = list.stream()
                 .map(CompletionStage::toCompletableFuture)
                 .collect(toList());
-        final CompletableFuture[] futuresAsArray = futureList.toArray(new CompletableFuture[futureList.size()]);
+        final CompletableFuture[] futuresAsArray = futureList.toArray(new CompletableFuture[0]);
         return CompletableFuture.allOf(futuresAsArray)
                 .thenApplyAsync(x -> futureList.stream().map(CompletableFuture::join).collect(Collectors.toList()));
     }


### PR DESCRIPTION
...iterations and unnecessary allocations

- Replace toMultimap() + stream + flatMap + collect with direct header iteration in OkHttp3/4/5 clients
- Replace stream().anyMatch() + getFirst() double iteration with single getFirst() null check in all HTTP clients
- Replace groupingBy + flatMap pattern in Apache HTTP client with direct array iteration
- Fix toArray(new CompletableFuture[size]) to toArray(new CompletableFuture[0]) in CompletableFutureUtils
- Replace String.format with concatenation in BaseAuthTokenSupplier logging
- Add explicit UTF-8 charset to new String(byte[]) in BaseAuthTokenSupplier

- [ ] Changeset added

### Features

### Fixes

### Breaking changes

